### PR TITLE
Fix acceleration update loop

### DIFF
--- a/MD_argon_crystalization.py
+++ b/MD_argon_crystalization.py
@@ -111,8 +111,6 @@ while t<=40000*dt:
     for i in range(0, N):
         x[i], vx[i] = verlet(x[i],vx[i],ax[i],axx[i],dt)
         y[i], vy[i] = verlet(y[i], vy[i], ay[i], ayy[i], dt)
-        ayy=np.copy(ay)
-        axx=np.copy(ax)
         if x[i] > L:
             x[i] = x[i] - L
         elif x[i] < 0:
@@ -121,6 +119,8 @@ while t<=40000*dt:
             y[i] = y[i] - L
         elif y[i] <0:
             y[i] = y[i] + L
+    axx=np.copy(ax)
+    ayy=np.copy(ay)
     #vcx=0
     #vcy=0
     


### PR DESCRIPTION
## Summary
- avoid copying acceleration arrays inside the particle loop
- update `axx` and `ayy` only once per simulation step

## Testing
- `python -m py_compile MD_argon_crystalization.py`

------
https://chatgpt.com/codex/tasks/task_e_6874c9e8a0908333a317d337c5e852bb